### PR TITLE
docs: fixed typo

### DIFF
--- a/content/lab-1/lab1.ipynb
+++ b/content/lab-1/lab1.ipynb
@@ -131,7 +131,7 @@
    "id": "1c585da8-60ed-4408-946d-c3b86759d231",
    "metadata": {},
    "source": [
-    "Primitives are meant to serve as an foundational, elementary, building blocks for users to perform quantum computations, developers to implement quantum algorithms, and researchers to solve complex problems and deliver new applications.\n",
+    "Primitives are meant to serve as foundational, elementary, building blocks for users to perform quantum computations, developers to implement quantum algorithms, and researchers to solve complex problems and deliver new applications.\n",
     "\n",
     "But before we go into its significance in terms of quantum computation, let's examine what the term \"primitive\" actually means and what it implies for us.\n",
     "\n",
@@ -2234,7 +2234,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.8.13"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
fixed subject verb agreement by removing 'an' in the line "Primitives are meant to serve as an foundational, elementary, building blocks for users to perform quantum computations, developers to implement quantum algorithms, and researchers to solve complex problems and deliver new applications."