### PR TITLE
Added code to create session to match provider when running on a real device

### DIFF
--- a/content/lab-1/lab1.ipynb
+++ b/content/lab-1/lab1.ipynb
@@ -1699,6 +1699,25 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ee32384b",
+   "metadata": {},
+   "source": [
+    "Set up session with selected backend."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0639f065",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "service = QiskitRuntimeService(channel=\"ibm_quantum\", instance='ibm-q/open/main') # Change according to the email provided\n",
+    "backend = service.backend(backend.name())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "12cb6437-6ba5-476b-9174-672bfec1c196",
    "metadata": {},
    "source": [
@@ -1723,7 +1742,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with Session(service=service, backend=backend.name()):\n",
+    "with Session(service=service, backend=backend):\n",
     "    sampler = Sampler(options=options)\n",
     "    job = sampler.run(circuits=[qc]*len(phases), parameter_values=individual_phases)\n",
     "    param_results = job.result()\n",
@@ -1761,32 +1780,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b1978ef0-0665-4c92-9efc-4c6400baf002",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from qiskit.providers.ibmq import least_busy\n",
-    "backend = least_busy(provider.backends(filters=lambda x: not x.configuration().simulator))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b2c932fb-9491-482c-8334-f86e0483a355",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "options_with_em = Options(resilience_level=1) # Change to see difference"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "ef4f5b6e-5bd0-4257-9dc6-5e32dafb5cd0",
    "metadata": {},
    "outputs": [],
    "source": [
-    "with Session(service=service, backend=backend.name()):    \n",
+    "with Session(service=service, backend=backend):    \n",
     "    estimator = Estimator(options=options)\n",
     "    job = estimator.run(circuits=[qc_no_meas]*len(phases), parameter_values=individual_phases, observables=[ZZ]*len(phases))\n",
     "    param_results = job.result()\n",
@@ -2234,7 +2232,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.8"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
Without added code, the wrong provider is used when submitting the job to real devices. 